### PR TITLE
Add function to retrieve configuration keys

### DIFF
--- a/kjmodulebedrock.php
+++ b/kjmodulebedrock.php
@@ -24,6 +24,7 @@ if (file_exists(dirname(__FILE__) . '/vendor/autoload.php')) {
 }
 
 use Kaudaj\Module\ModuleBedrock\Form\Settings\GeneralConfiguration;
+use Kaudaj\Module\ModuleBedrock\Form\Settings\GeneralType;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -31,14 +32,12 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class KJModuleBedrock extends Module
 {
     /**
-     * @var array<string, string> Configuration values
+     * @var array<string, string> Configuration values to install/uninstall
      */
-    public const CONFIGURATION_VALUES = [
-        GeneralConfiguration::EXAMPLE_SETTING_KEY => 'default_value',
-    ];
+    public $configurationValues = [];
 
     /**
-     * @var string[] Hooks to register
+     * @var string[] Hooks to register/unregister
      */
     public const HOOKS = [
         'exampleHook',
@@ -83,6 +82,10 @@ EOF
         ];
 
         $this->configuration = new Configuration();
+
+        $this->configurationValues = [
+            GeneralConfiguration::getConfigurationKey(GeneralType::FIELD_EXAMPLE_SETTING) => 'default_value',
+        ];
     }
 
     /**
@@ -110,8 +113,8 @@ EOF
     private function installConfiguration(): bool
     {
         try {
-            foreach (self::CONFIGURATION_VALUES as $key => $default_value) {
-                $this->configuration->set($key, $default_value);
+            foreach ($this->configurationValues as $key => $defaultValue) {
+                $this->configuration->set($key, $defaultValue);
             }
         } catch (Exception $e) {
             return false;
@@ -136,7 +139,7 @@ EOF
     private function uninstallConfiguration(): bool
     {
         try {
-            foreach (array_keys(self::CONFIGURATION_VALUES) as $key) {
+            foreach (array_keys($this->configurationValues) as $key) {
                 $this->configuration->remove($key);
             }
         } catch (Exception $e) {

--- a/src/Form/Settings/GeneralConfiguration.php
+++ b/src/Form/Settings/GeneralConfiguration.php
@@ -29,16 +29,8 @@ use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
  */
 final class GeneralConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var string
-     */
-    public const EXAMPLE_SETTING_KEY = 'KJ_MODULE_BEDROCK_EXAMPLE_SETTING';
-
-    /**
-     * @var array<string, string>
-     */
-    private $fields = [
-        'example_setting' => self::EXAMPLE_SETTING_KEY,
+    private const CONFIGURATION_FIELDS = [
+        GeneralType::FIELD_EXAMPLE_SETTING,
     ];
 
     /**
@@ -50,8 +42,8 @@ final class GeneralConfiguration extends AbstractMultistoreConfiguration
     {
         $configurationValues = [];
 
-        foreach ($this->fields as $field => $configurationKey) {
-            $configurationValues[$field] = $this->configuration->get($configurationKey);
+        foreach (self::CONFIGURATION_FIELDS as $field) {
+            $configurationValues[$field] = $this->configuration->get($this->getConfigurationKey($field));
         }
 
         return $configurationValues;
@@ -78,8 +70,8 @@ final class GeneralConfiguration extends AbstractMultistoreConfiguration
             $shopConstraint = $this->getShopConstraint();
 
             try {
-                foreach ($this->fields as $field => $configurationKey) {
-                    $this->updateConfigurationValue($configurationKey, $field, $configuration, $shopConstraint);
+                foreach (self::CONFIGURATION_FIELDS as $field) {
+                    $this->updateConfigurationValue($this->getConfigurationKey($field), $field, $configuration, $shopConstraint);
                 }
             } catch (\Exception $exception) {
                 $errors[] = [
@@ -102,17 +94,23 @@ final class GeneralConfiguration extends AbstractMultistoreConfiguration
      */
     public function validateConfiguration(array $configuration): bool
     {
-        foreach ($this->fields as $field => $configurationKey) {
+        $fields = self::CONFIGURATION_FIELDS;
+        foreach (self::CONFIGURATION_FIELDS as $field) {
             $multistoreKey = MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . $field;
-            $this->fields[$multistoreKey] = '';
+            $fields[] = $multistoreKey;
         }
 
-        foreach ($configuration as $key => $value) {
-            if (!key_exists($key, $this->fields)) {
+        foreach (array_keys($configuration) as $field) {
+            if (!in_array($field, $fields)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    public static function getConfigurationKey(string $fieldName): string
+    {
+        return 'KJ_MODULE_BEDROCK_' . strtoupper($fieldName);
     }
 }

--- a/src/Form/Settings/GeneralType.php
+++ b/src/Form/Settings/GeneralType.php
@@ -28,6 +28,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class GeneralType extends TranslatorAwareType
 {
+    public const FIELD_EXAMPLE_SETTING = 'example_setting';
+
     /**
      * {@inheritdoc}
      *
@@ -37,11 +39,11 @@ class GeneralType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('example_setting', TextType::class, [
+            ->add(self::FIELD_EXAMPLE_SETTING, TextType::class, [
                 'label' => $this->trans('Example setting', 'Modules.Kjmodulebedrock.Admin'),
                 'help' => $this->trans('Help user to fill this field.', 'Modules.Kjmodulebedrock.Admin'),
                 'required' => false,
-                'multistore_configuration_key' => GeneralConfiguration::EXAMPLE_SETTING_KEY,
+                'multistore_configuration_key' => GeneralConfiguration::getConfigurationKey(self::FIELD_EXAMPLE_SETTING),
             ]);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project! 

Please take the time to edit the "Answers" rows below with the necessary information.

You should check out PrestaShop contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add a function to retrieve configuration key for a field in order to avoid writing them literally.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
